### PR TITLE
Add merge_all_summaries method

### DIFF
--- a/lib/ssnet_trainval.py
+++ b/lib/ssnet_trainval.py
@@ -308,6 +308,11 @@ class ssnet_trainval(object):
       else:
         self.ana_step()
 
+  def merge_all_summaries(self):
+    # Update network's merged summary
+    if hasattr(self, '_net') and hasattr(self._net, '_merged_summary'):
+      self._net._merged_summary = tf.summary.merge_all()
+
   def iterations(self):
     return self._cfg.ITERATIONS
 


### PR DESCRIPTION
To be able to add your own summaries and relaunch tf.summary.merge_all()
without having to dig into _net._merged_summary attributes.

Currently I have to do :
```
import ssnet_trainval as api
t = api.ssnet_trainval()
# (...) Define ssnet_config (...)
# Initialize
t.override_config(ssnet_config.name)
t.initialize()
# Add your own summaries
tf.summary.scalar('test_value', tf.constant(37.0))
t._net._merged_summary = tf.summary.merge_all()
# Start training...
```
The user shouldn't have to mess with `t._net._merged_summary`. Instead we could just have
```
# Add your own summaries
tf.summary.scalar('test_value', tf.constant(37.0))
t.merge_all_summaries()
```